### PR TITLE
Update field name conversion to use new FieldService from Discoverer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.1",
         "silverstripe/framework": "^5",
-        "silverstripe/silverstripe-discoverer": "^1.1",
+        "silverstripe/silverstripe-discoverer": "^1.2",
         "elastic/enterprise-search": "^8.10",
         "guzzlehttp/guzzle": "^7.5"
     },

--- a/src/Processors/ResultsProcessor.php
+++ b/src/Processors/ResultsProcessor.php
@@ -8,6 +8,7 @@ use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Discoverer\Analytics\AnalyticsData;
 use SilverStripe\Discoverer\Analytics\AnalyticsMiddleware;
+use SilverStripe\Discoverer\Service\FieldService;
 use SilverStripe\Discoverer\Service\Results\Facet;
 use SilverStripe\Discoverer\Service\Results\FacetData;
 use SilverStripe\Discoverer\Service\Results\Field;
@@ -182,7 +183,7 @@ class ResultsProcessor
 
             foreach ($result as $fieldName => $valueFields) {
                 // Convert snake_case (Elastic's field name format) to PascalCase (Silverstripe's field name format)
-                $formattedFieldName = $this->getConvertedFieldName($fieldName);
+                $formattedFieldName = FieldService::singleton()->getConvertedFieldName($fieldName);
 
                 $raw = $valueFields['raw'] ?? null;
                 $snippet = $valueFields['snippet'] ?? null;
@@ -239,11 +240,6 @@ class ResultsProcessor
                 $results->addFacet($facet);
             }
         }
-    }
-
-    private function getConvertedFieldName(string $fieldName): string
-    {
-        return str_replace('_', '', ucwords($fieldName, '_'));
     }
 
 }

--- a/tests/Processors/ResultsProcessorTest.php
+++ b/tests/Processors/ResultsProcessorTest.php
@@ -160,30 +160,6 @@ class ResultsProcessorTest extends SapphireTest
         $reflectionMethod->invoke($resultsProcessor, $response);
     }
 
-    /**
-     * @dataProvider provideFieldNames
-     */
-    public function testGetConvertedFieldName(string $fieldName, string $expectedFieldName): void
-    {
-        $resultsProcessor = ResultsProcessor::singleton();
-
-        /** @see ResultsProcessor::getConvertedFieldName() */
-        $reflectionMethod = new ReflectionMethod($resultsProcessor, 'getConvertedFieldName');
-        $reflectionMethod->setAccessible(true);
-
-        $this->assertEquals($expectedFieldName, $reflectionMethod->invoke($resultsProcessor, $fieldName));
-    }
-
-    public function provideFieldNames(): array
-    {
-        return [
-            ['title', 'Title'],
-            ['elemental_area', 'ElementalArea'],
-            ['record_id', 'RecordId'],
-            ['tag_ids', 'TagIds'],
-        ];
-    }
-
     public function testProcessMetaData(): void
     {
         $resultsProcessor = ResultsProcessor::singleton();

--- a/tests/Processors/ResultsProcessorTest.php
+++ b/tests/Processors/ResultsProcessorTest.php
@@ -200,8 +200,15 @@ class ResultsProcessorTest extends SapphireTest
 
         /** @var Record $record */
         $record = $results->getRecords()->getList()->first();
+
         // Start testing that the snake_case fields from Elastic are converted to Silverstripe PascalCase equivalents,
         // and that we have our expected Raw and Snippet values
+        $this->assertTrue($record->hasDynamicData('Title'));
+        $this->assertTrue($record->hasDynamicData('Description'));
+        $this->assertTrue($record->hasDynamicData('Id'));
+        $this->assertTrue($record->hasDynamicData('RecordId'));
+        $this->assertTrue($record->hasDynamicData('SourceClass'));
+
         /** @var Field $title */
         $title = $record->Title;
         /** @var Field $description */


### PR DESCRIPTION
Depends on https://github.com/silverstripeltd/silverstripe-discoverer/pull/18

We'll need to wait for that to be merged, a new version tagged, and then we can update the minimum requirements here.

Breaking tests: To be expected until the above is merged/tagged.