### PR TITLE
Set facet data name as part of result object

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^8.1",
         "silverstripe/framework": "^5",
-        "silverstripe/silverstripe-discoverer": "^2",
+        "silverstripe/silverstripe-discoverer": "^2.1.0",
         "elastic/enterprise-search": "^8.10",
         "guzzlehttp/guzzle": "^7.5"
     },

--- a/src/Processors/ResultsProcessor.php
+++ b/src/Processors/ResultsProcessor.php
@@ -229,6 +229,7 @@ class ResultsProcessor
 
                 foreach ($facetResult['data'] as $resultData) {
                     $facetData = FacetData::create();
+                    $facetData->setName($resultData['name'] ?? '');
                     $facetData->setValue($resultData['value'] ?? '');
                     $facetData->setFrom($resultData['from'] ?? '');
                     $facetData->setTo($resultData['to'] ?? '');


### PR DESCRIPTION
Will require https://github.com/silverstripeltd/silverstripe-discoverer/pull/25 to be merged and tagged first.

While playing around with Facets on App Search, I noticed that it was possible to set a "name" for facet data. For example, if you have a range facet, you can give each range definition an identifier (name).